### PR TITLE
fix: function "elseif" not defined on helm 2.7.0

### DIFF
--- a/rawsnippets/ifelse.tpl
+++ b/rawsnippets/ifelse.tpl
@@ -1,6 +1,6 @@
 {{- if ${1:condition} -}}
   ${2}
-{{- elseif ${3:condition2} -}}
+{{- else if ${3:condition2} -}}
   ${4}
 {{- else -}}
   ${5}


### PR DESCRIPTION
I've experienced a `function "elseif" not defined` error after using the `ifelse` Snippet.
This PR inserts the required space character so that helm can successfully render the template.

My Version of Helm:
```
$ helm version
Client: &version.Version{SemVer:"v2.7.0", GitCommit:"08c1144f5eb3e3b636d9775617287cc26e53dba4", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.7.0", GitCommit:"08c1144f5eb3e3b636d9775617287cc26e53dba4", GitTreeState:"clean"}
```